### PR TITLE
fix finishThread is not closed after workflow is closed

### DIFF
--- a/src/main/java/cws/k8s/scheduler/scheduler/Scheduler.java
+++ b/src/main/java/cws/k8s/scheduler/scheduler/Scheduler.java
@@ -494,6 +494,7 @@ public abstract class Scheduler implements Informable {
     public void close(){
         watcher.close();
         schedulingThread.interrupt();
+        finishThread.interrupt();
         this.close = true;
     }
 


### PR DESCRIPTION
It apears that finishThread.interrupt(); is missing here.