### PR TITLE
fix that task gets inserted multiple times into unfinishedTasks

### DIFF
--- a/src/main/java/cws/k8s/scheduler/model/State.java
+++ b/src/main/java/cws/k8s/scheduler/model/State.java
@@ -2,6 +2,13 @@ package cws.k8s.scheduler.model;
 
 public enum State {
 
-    RECEIVED_CONFIG, UNSCHEDULED, SCHEDULED, PREPARED, ERROR, PROCESSING_FINISHED, FINISHED, FINISHED_WITH_ERROR, INIT_WITH_ERRORS, DELETED
+    RECEIVED_CONFIG(0), UNSCHEDULED(1), SCHEDULED(2), PREPARED(3), INIT_WITH_ERRORS(3), PROCESSING_FINISHED(4),
+    FINISHED(5), FINISHED_WITH_ERROR(5), ERROR(1000), DELETED(Integer.MAX_VALUE);
+
+    public final int level;
+
+    State(int level) {
+        this.level = level;
+    }
 
 }

--- a/src/main/java/cws/k8s/scheduler/scheduler/Scheduler.java
+++ b/src/main/java/cws/k8s/scheduler/scheduler/Scheduler.java
@@ -169,6 +169,13 @@ public abstract class Scheduler implements Informable {
     void podEventReceived(Watcher.Action action, Pod pod){}
 
     void onPodTermination( PodWithAge pod ){
+        // check if task already was processed
+        Task task = getTaskByPod(pod);
+        if (task.getState().getState() == State.FINISHED || task.getState().getState() == State.FINISHED_WITH_ERROR) {
+            log.debug("already finished, nothing to do!");
+            return;
+        }
+
         Task t = changeStateOfTask( pod, State.PROCESSING_FINISHED );
 
         //If null, task was already changed

--- a/src/main/java/cws/k8s/scheduler/scheduler/Scheduler.java
+++ b/src/main/java/cws/k8s/scheduler/scheduler/Scheduler.java
@@ -168,14 +168,7 @@ public abstract class Scheduler implements Informable {
 
     void podEventReceived(Watcher.Action action, Pod pod){}
 
-    void onPodTermination( PodWithAge pod ){
-        // check if task already was processed
-        Task task = getTaskByPod(pod);
-        if (task.getState().getState() == State.FINISHED || task.getState().getState() == State.FINISHED_WITH_ERROR) {
-            log.debug("already finished, nothing to do!");
-            return;
-        }
-
+    void onPodTermination( PodWithAge pod ) {
         Task t = changeStateOfTask( pod, State.PROCESSING_FINISHED );
 
         //If null, task was already changed

--- a/src/main/java/cws/k8s/scheduler/scheduler/Scheduler.java
+++ b/src/main/java/cws/k8s/scheduler/scheduler/Scheduler.java
@@ -422,14 +422,16 @@ public abstract class Scheduler implements Informable {
     /**
      * @return returns the task, if the state was changed
      */
-    Task changeStateOfTask(Pod pod, State state){
-        Task t = getTaskByPod( pod );
-        if( t != null ){
-            synchronized ( t.getState() ){
-                if( t.getState().getState() != state ){
-                    t.getState().setState( state );
+    Task changeStateOfTask(Pod pod, State state) {
+        Task t = getTaskByPod(pod);
+        if (t != null) {
+            synchronized (t.getState()) {
+                if (t.getState().getState().level < state.level) {
+                    t.getState().setState(state);
                     return t;
                 } else {
+                    log.warn("Task {} was already in state {} and cannot be changed to {}", t.getConfig().getRunName(),
+                            t.getState().getState(), state);
                     return null;
                 }
             }

--- a/src/main/java/cws/k8s/scheduler/scheduler/Scheduler.java
+++ b/src/main/java/cws/k8s/scheduler/scheduler/Scheduler.java
@@ -168,7 +168,7 @@ public abstract class Scheduler implements Informable {
 
     void podEventReceived(Watcher.Action action, Pod pod){}
 
-    void onPodTermination( PodWithAge pod ) {
+    void onPodTermination( PodWithAge pod ){
         Task t = changeStateOfTask( pod, State.PROCESSING_FINISHED );
 
         //If null, task was already changed
@@ -423,7 +423,7 @@ public abstract class Scheduler implements Informable {
                     t.getState().setState(state);
                     return t;
                 } else {
-                    log.warn("Task {} was already in state {} and cannot be changed to {}", t.getConfig().getRunName(),
+                    log.debug("Task {} was already in state {} and cannot be changed to {}", t.getConfig().getRunName(),
                             t.getState().getState(), state);
                     return null;
                 }


### PR DESCRIPTION
There is a problem with the pod/task termination, so that a task is inserted multiple times into the unfinishedTasks List.

I believe the cause is, that onPodTermination() would reset tasks that are already FINISHED or FINISHED_WITH_ERRORS back to PROCESSING_FINISHED.

This change fixes the issue in my local test setup.