### PR TITLE
Feature springboot update

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ 17, 19 ]
+        java_version: [ 17, 21 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ 11, 19 ]
+        java_version: [ 17, 19 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -32,10 +32,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
       - name: Set outputs
         id: vars

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.3-jdk-11-slim AS build
+FROM maven:3-openjdk-17-slim AS build
 WORKDIR /build
 COPY pom.xml pom.xml
 RUN mvn dependency:go-offline --no-transfer-progress -Dmaven.repo.local=/mvn/.m2nrepo/repository

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ docker push <your docker account>/cws:<version>
 | 11 | /{version}/{execution}/task/{id}    | DELETE |
 
 SWAGGER:  /swagger-ui.html <br>
-API-DOCS: /v3/api-docs/
+API-DOCS: /v3/api-docs
 
 For more details, we refer to the paper.
 

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-<!--
                 <executions>
                     <execution>
                         <id>build-info</id>
@@ -227,7 +226,6 @@
                         </goals>
                     </execution>
                 </executions>
--->
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+<!--
                 <executions>
                     <execution>
                         <id>build-info</id>
@@ -226,6 +227,7 @@
                         </goals>
                     </execution>
                 </executions>
+-->
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     </scm>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <start-class>cws.k8s.scheduler.Main</start-class>
     </properties>
 
@@ -215,7 +215,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-<!--
                 <executions>
                     <execution>
                         <id>build-info</id>
@@ -224,7 +223,6 @@
                         </goals>
                     </execution>
                 </executions>
--->
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -109,11 +109,12 @@
             <version>3.8.0</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.6.15</version>
-        </dependency>
+       <dependency>
+          <groupId>org.springdoc</groupId>
+          <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+          <version>2.2.0</version>
+       </dependency>
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
@@ -137,6 +138,7 @@
 
     <build>
         <plugins>
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -171,6 +173,7 @@
                     </execution>
                 </executions>
             </plugin>
+            -->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+<!--
                 <executions>
                     <execution>
                         <id>build-info</id>
@@ -223,6 +224,7 @@
                         </goals>
                     </execution>
                 </executions>
+-->
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.2</version>
+        <version>3.1.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -15,9 +15,28 @@
     <artifactId>cws-k8s-scheduler</artifactId>
     <version>1.2-SNAPSHOT</version>
 
+    <name>Common Workflow Scheduler for Kubernetes</name>
+    <description>The Common Workflow Scheduler for Kubernetes proposed in the paper "How Workflow Engines Should Talk to Resource Managers: A Proposal for a Common Workflow Scheduling Interface."</description>
+    <licenses>
+        <license>
+            <name>GPL-3.0-or-later</name>
+            <url>https://www.gnu.org/licenses/gpl-3.0-standalone.html</url>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name></name>
+            <email></email>
+            <organization></organization>
+            <organizationUrl></organizationUrl>
+        </developer>
+    </developers>
+    <scm>
+        <url>https://github.com/CommonWorkflowScheduler/KubernetesScheduler</url>
+    </scm>
+
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <java.version>11</java.version>
         <start-class>cws.k8s.scheduler.Main</start-class>
     </properties>
 
@@ -38,14 +57,12 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.26</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
         </dependency>
 
         <dependency>
@@ -58,13 +75,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>3.0.4</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>3.0.4</version>
             <scope>test</scope>
         </dependency>
 
@@ -78,7 +93,6 @@
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -103,24 +117,20 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.4.6</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.2</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.15.0-rc2</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.15.0-rc2</version>
         </dependency>
 
     </dependencies>
@@ -188,7 +198,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
                 <configuration>
                     <!-- redirectTestOutputToFile>true</redirectTestOutputToFile -->
                     <argLine>${surefireArgLine} --illegal-access=permit</argLine>

--- a/src/main/java/cws/k8s/scheduler/Main.java
+++ b/src/main/java/cws/k8s/scheduler/Main.java
@@ -6,7 +6,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.info.BuildProperties;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  mvc:
+    pathmatch:
+      matching-strategy: ant-path-matcher


### PR DESCRIPTION
( Retry for https://github.com/CommonWorkflowScheduler/KubernetesScheduler/pull/5 )

This will update the Spring Boot Version to 3.1.5 and fixes some inconsistencies in the buildfile.

    Due to the inheritance of Spring Boot, it is required to overwrite some of the fields explicit (see https://maven.apache.org/pom.html#More_Project_Information )

    javax.annotation.PostConstruct has been renamed to jakarta.annotation.PostConstruct

    Some of the dependencies are actually not needed, because spring-boot-starters do pull in those as dependencies. The cleanup should be done in a second sweep (not included here).

    The explicit version statements for some dependencies have been removed, leading to fhe following changes:

           <groupId>org.projectlombok</groupId>
           <artifactId>lombok</artifactId>
           <version>1.18.26</version> -> managed: 1.18.30

           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
           <version>4.13.2</version> -> managed: 4.13.2

           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-web</artifactId>
           <version>3.0.4</version> -> managed: 3.1.5

           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-test</artifactId>
           <version>3.0.4</version> -> managed: 3.1.5

           <groupId>org.junit.vintage</groupId>
           <artifactId>junit-vintage-engine</artifactId>
          <version>5.9.2</version> -> managed: 4.13.2

           <groupId>ch.qos.logback</groupId>
           <artifactId>logback-core</artifactId>
           <version>1.4.6</version> -> managed: 1.4.11

           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
           <version>2.14.2</version> -> managed: 2.15.3

           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-core</artifactId>
           <version>2.15.0-rc2</version> -> managed: 2.15.3

           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
           <version>2.15.0-rc2</version> -> managed: 2.15.3

               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
               <version>3.0.0-M5</version> -> managed: 3.0.0
