### PR TITLE
Replace default kubernetes client

### DIFF
--- a/src/main/java/cws/k8s/scheduler/client/CWSKubernetesClient.java
+++ b/src/main/java/cws/k8s/scheduler/client/CWSKubernetesClient.java
@@ -23,7 +23,8 @@ public class CWSKubernetesClient {
 
 
     public CWSKubernetesClient(){
-        this.client = new DefaultKubernetesClient();
+        KubernetesClientBuilder builder = new KubernetesClientBuilder();
+        this.client = builder.build();
         for( Node node : this.nodes().list().getItems() ){
             nodeHolder.put( node.getMetadata().getName(), new NodeWithAlloc(node,this) );
         }

--- a/src/main/java/cws/k8s/scheduler/client/CWSKubernetesClient.java
+++ b/src/main/java/cws/k8s/scheduler/client/CWSKubernetesClient.java
@@ -18,11 +18,12 @@ import java.util.*;
 public class CWSKubernetesClient {
 
     private final KubernetesClient client;
+
     private final Map<String, NodeWithAlloc> nodeHolder = new HashMap<>();
     private final List<Informable> informables = new LinkedList<>();
 
 
-    public CWSKubernetesClient(){
+    public CWSKubernetesClient() {
         KubernetesClientBuilder builder = new KubernetesClientBuilder();
         this.client = builder.build();
         for( Node node : this.nodes().list().getItems() ){

--- a/src/main/java/cws/k8s/scheduler/config/Beans.java
+++ b/src/main/java/cws/k8s/scheduler/config/Beans.java
@@ -1,6 +1,6 @@
 package cws.k8s.scheduler.config;
 
-import cws.k8s.scheduler.client.KubernetesClient;
+import cws.k8s.scheduler.client.CWSKubernetesClient;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -10,12 +10,12 @@ import org.springframework.context.annotation.Configuration;
 @RequiredArgsConstructor( access = AccessLevel.PACKAGE )
 public class Beans {
 
-    private static KubernetesClient kubernetesClient;
+    private static CWSKubernetesClient kubernetesClient;
 
     @Bean
-    KubernetesClient getClient(){
+    CWSKubernetesClient getClient(){
         if(kubernetesClient == null) {
-            kubernetesClient = new KubernetesClient();
+            kubernetesClient = new CWSKubernetesClient();
             kubernetesClient.getConfiguration().setNamespace(null);
         }
         return kubernetesClient;

--- a/src/main/java/cws/k8s/scheduler/model/NodeWithAlloc.java
+++ b/src/main/java/cws/k8s/scheduler/model/NodeWithAlloc.java
@@ -1,6 +1,6 @@
 package cws.k8s.scheduler.model;
 
-import cws.k8s.scheduler.client.KubernetesClient;
+import cws.k8s.scheduler.client.CWSKubernetesClient;
 import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -16,7 +16,7 @@ import java.util.*;
 @Slf4j
 public class NodeWithAlloc extends Node implements Comparable<NodeWithAlloc> {
 
-    private final transient KubernetesClient kubernetesClient;
+    private final transient CWSKubernetesClient kubernetesClient;
 
     private static final long serialVersionUID = 1L;
 
@@ -34,7 +34,7 @@ public class NodeWithAlloc extends Node implements Comparable<NodeWithAlloc> {
         this.getMetadata().setName( name );
     }
 
-    public NodeWithAlloc( Node node, KubernetesClient kubernetesClient ) {
+    public NodeWithAlloc( Node node, CWSKubernetesClient kubernetesClient ) {
 
         this.kubernetesClient = kubernetesClient;
 

--- a/src/main/java/cws/k8s/scheduler/rest/SchedulerRestController.java
+++ b/src/main/java/cws/k8s/scheduler/rest/SchedulerRestController.java
@@ -2,7 +2,7 @@ package cws.k8s.scheduler.rest;
 
 import cws.k8s.scheduler.dag.DAG;
 import cws.k8s.scheduler.dag.InputEdge;
-import cws.k8s.scheduler.client.KubernetesClient;
+import cws.k8s.scheduler.client.CWSKubernetesClient;
 import cws.k8s.scheduler.dag.Vertex;
 import cws.k8s.scheduler.model.SchedulerConfig;
 import cws.k8s.scheduler.model.TaskConfig;
@@ -37,7 +37,7 @@ import java.util.Map;
 @EnableScheduling
 public class SchedulerRestController {
 
-    private final KubernetesClient client;
+    private final CWSKubernetesClient client;
     private final boolean autoClose;
     private final ApplicationContext appContext;
     private long closedLastScheduler = -1;
@@ -50,7 +50,7 @@ public class SchedulerRestController {
     private static final Map<String, Scheduler> schedulerHolder = new HashMap<>();
 
     public SchedulerRestController(
-            @Autowired KubernetesClient client,
+            @Autowired CWSKubernetesClient client,
             @Value("#{environment.AUTOCLOSE}") String autoClose,
             @Autowired ApplicationContext appContext ){
         this.client = client;

--- a/src/main/java/cws/k8s/scheduler/scheduler/PrioritizeAssignScheduler.java
+++ b/src/main/java/cws/k8s/scheduler/scheduler/PrioritizeAssignScheduler.java
@@ -3,7 +3,7 @@ package cws.k8s.scheduler.scheduler;
 import cws.k8s.scheduler.model.*;
 import cws.k8s.scheduler.scheduler.prioritize.Prioritize;
 import cws.k8s.scheduler.client.Informable;
-import cws.k8s.scheduler.client.KubernetesClient;
+import cws.k8s.scheduler.client.CWSKubernetesClient;
 import cws.k8s.scheduler.scheduler.nodeassign.NodeAssign;
 import cws.k8s.scheduler.util.NodeTaskAlignment;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +17,7 @@ public class PrioritizeAssignScheduler extends Scheduler {
     private final NodeAssign nodeAssigner;
 
     public PrioritizeAssignScheduler( String execution,
-                                      KubernetesClient client,
+                                      CWSKubernetesClient client,
                                       String namespace,
                                       SchedulerConfig config,
                                       Prioritize prioritize,

--- a/src/main/java/cws/k8s/scheduler/scheduler/Scheduler.java
+++ b/src/main/java/cws/k8s/scheduler/scheduler/Scheduler.java
@@ -4,7 +4,7 @@ import cws.k8s.scheduler.dag.DAG;
 import cws.k8s.scheduler.model.*;
 import cws.k8s.scheduler.util.Batch;
 import cws.k8s.scheduler.client.Informable;
-import cws.k8s.scheduler.client.KubernetesClient;
+import cws.k8s.scheduler.client.CWSKubernetesClient;
 import cws.k8s.scheduler.util.NodeTaskAlignment;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.Watch;
@@ -40,7 +40,7 @@ public abstract class Scheduler implements Informable {
     private int currentBatch = 0;
     private Batch currentBatchInstance = null;
 
-    final KubernetesClient client;
+    final CWSKubernetesClient client;
     private final Set<Task> upcomingTasks = new HashSet<>();
     private final List<Task> unscheduledTasks = new ArrayList<>( 100 );
     private final List<Task> unfinishedTasks = new ArrayList<>( 100 );
@@ -52,7 +52,7 @@ public abstract class Scheduler implements Informable {
 
     final boolean traceEnabled;
 
-    Scheduler(String execution, KubernetesClient client, String namespace, SchedulerConfig config){
+    Scheduler(String execution, CWSKubernetesClient client, String namespace, SchedulerConfig config){
         this.execution = execution;
         this.name = System.getenv( "SCHEDULER_NAME" ) + "-" + execution;
         this.namespace = namespace;


### PR DESCRIPTION
This PR replaces the deprecated `DefaultKubernetesClient` with a Builder-based approach.
The previous `KubernetesClient` was renamed to `CWSKubernetesClient` to not interfere with the `KubernetesClient` interface from the Fabric8 Kubernetes API.
The `CWSKubernetesClient` now delegates to a `KubernetesClient` instead of inheriting from it.
